### PR TITLE
[tendermint/rust-abci] replace deprecated repo w/ an active fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@
 - [slingshot](https://github.com/stellar/slingshot).
   A new blockchain architecture under active development, with a
   strong focus on scalability, privacy and safety.
-- [Tendermint ABCI](https://github.com/tendermint/rust-abci).
+- [Tendermint ABCI](https://github.com/informalsystems/tendermint-rs/tree/master/abci).
   Tendermint ABCI server, written in the Rust programming language.
 - [Orga](https://github.com/nomic-io/orga).
   A high-performance state machine engine designed for


### PR DESCRIPTION
https://github.com/tendermint/rust-abci has been archived by the owner on Mar 11, 2021. It is now read-only. Development work continues as the "abci" crate of informalsystems/tendermint-rs.