### PR TITLE
Add RustChain — Proof-of-Antiquity blockchain written in Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@
 - [ERC-4337 Bundler](https://github.com/Vid201/aa-bundler/).
   An ongoing Rust implementation of an ERC-4337 (Account Abstraction) Bundler.
 - [Solana VS Code Extension](https://github.com/Ackee-Blockchain/solana-vscode).
+- [RustChain](https://github.com/Scottcjn/Rustchain) - Proof-of-Antiquity blockchain that rewards vintage hardware for running AI inference. Old computers earn more RTC tokens than new ones.
   VS Code extension for Solana with built-in static analysis detectors and fuzzing coverage visualization.
 
 ## Contribute


### PR DESCRIPTION
Adding [RustChain](https://github.com/Scottcjn/Rustchain) to the Blockchains section.

RustChain is a Proof-of-Antiquity consensus blockchain where vintage hardware earns more RTC tokens than modern hardware. A PowerPC G4 Mac earns a higher antiquity multiplier than a new GPU rig. The node software is written in Rust and Python.

Fits the list because: Rust-based blockchain node, novel consensus mechanism, active development.