### PR TITLE
Add 7/Seven Chain Node — EVM perpetual futures blockchain (Chain ID: 70007)

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,3 +290,5 @@ License](http://i.creativecommons.org/l/by/4.0/88x31.png)](http://creativecommon
 
 This work is licensed under a [Creative Commons Attribution 4.0
 International License](http://creativecommons.org/licenses/by/4.0/).
+
+- [7/Seven Chain Node](https://github.com/umairkhan2582/seven-chain-node) - Validator node for 7/Seven Chain (Chain ID: 70007), an EVM-compatible blockchain (BSC/Parlia fork) powering [TheSeven.meme](https://theseven.meme) — perpetual futures exchange with 100+ pairs, up to 2001× leverage, zero fees.


### PR DESCRIPTION
## 7/Seven Chain Node

Adding [7/Seven Chain Node](https://github.com/umairkhan2582/seven-chain-node) to this list.

**What is it?**
7/Seven Chain is an EVM-compatible blockchain (BSC/Parlia consensus, Chain ID: 70007) powering [TheSeven.meme](https://theseven.meme):
- 100+ trading pairs (BTC, ETH, DOGE, PEPE, SHIB + more)
- Up to **2001× leverage** | **Zero trading fees** | On-chain settlement

**Links:**
- Node Repo: https://github.com/umairkhan2582/seven-chain-node
- Exchange: https://theseven.meme
- RPC: https://rpc.theseven.meme | Chain ID: 70007
- Explorer: https://theseven.meme/blockchain/explorer