### PR TITLE
Add RustChain - Proof-of-Antiquity blockchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@
   An ongoing Rust implementation of a Zcash node.
 - [Zero-chain](https://github.com/LayerXcom/zero-chain).
   A privacy-preserving blockchain on Substrate.
+- [RustChain](https://github.com/Scottcjn/Rustchain).
+  Proof-of-Antiquity blockchain that rewards vintage hardware. Older computers earn higher yields.
 
 ## Blockchain Frameworks
 - [Substrate](https://github.com/paritytech/substrate).


### PR DESCRIPTION
## RustChain Addition

Added RustChain to the Blockchains section.

**RustChain** - Proof-of-Antiquity blockchain that rewards vintage hardware. Older computers earn higher yields.

- GitHub: https://github.com/Scottcjn/Rustchain
- Website: https://rustchain.org

**Why RustChain fits:**
- Built with Rust
- Novel Proof-of-Antiquity consensus
- Rewards vintage hardware mining

---
**Wallet: chenzhizhuan**