### PR TITLE
Add RustChain to Blockchains section

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@
   for the issuance, lifecycle management and settlement of regulated securities.
 - [Radix](https://github.com/radixdlt/radixdlt-scrypto).
   Sharded smart contract DeFi platform.
+- [RustChain](https://github.com/Scottcjn/Rustchain).
+  Proof-of-Antiquity blockchain that rewards vintage hardware. Old computers earn more than new ones.
 - [RsNano](https://github.com/simpago/rsnano-node).
   A rust port of Nano: the eco-friendly & feeless digital currency
 - [Setheum](https://github.com/Setheum-Labs/Setheum).


### PR DESCRIPTION
Hi! I'd like to add [RustChain](https://github.com/Scottcjn/Rustchain) to the Blockchains section.

RustChain is a Proof-of-Antiquity blockchain that rewards vintage hardware — old computers earn more than new ones. It supports 15+ CPU architectures including PowerPC, SPARC, MIPS, and ARM, and has a Rust+Python hybrid chain with a Solana bridge (wRTC).

Thanks for maintaining this awesome list!