### PR TITLE
feat: add TWZRD Agent Intel to Dapps

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@
 - [ink!athon](https://github.com/scio-labs/inkathon).
   Full-Stack DApp Boilerplate for Substrate and ink! Smart Contracts.
 
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - MCP server for on-chain trust scoring of AI agent wallets on Solana. Query wallet identity, transaction history, and autonomy score.
 ## Other
 - [abscissa](https://github.com/iqlusioninc/abscissa).
   Micro-framework for CLI tools with strong focus on security.


### PR DESCRIPTION
## Description

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the Dapps section.

TWZRD Agent Intel is a Solana dapp that provides trust scoring for AI agent wallets via an MCP (Model Context Protocol) server. Built on Solana, it lets any AI application query on-chain behavioral evidence for wallet identity verification.

Free MCP: `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}`