### PR TITLE
Add RustChain - Proof of Antiquity blockchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@
   Sharded smart contract DeFi platform.
 - [RsNano](https://github.com/simpago/rsnano-node).
   A rust port of Nano: the eco-friendly & feeless digital currency
+- [RustChain](https://github.com/Scottcjn/Rustchain).
+  Proof of Antiquity blockchain that rewards vintage hardware mining.
 - [Secret Network](https://github.com/SecretFoundation/SecretNetwork).
   A privacy-first blockchain that uses Rust to enable "secret contracts", ensuring data is encrypted while being processed on-chain.
 - [Setheum](https://github.com/Setheum-Labs/Setheum).


### PR DESCRIPTION
Add [RustChain](https://github.com/Scottcjn/Rustchain) to the Blockchains section.

RustChain is a Proof of Antiquity blockchain that rewards vintage hardware mining. It is built in Rust and fits the curated list of blockchain-related Rust projects.

Closes https://github.com/Scottcjn/rustchain-bounties/issues/1592